### PR TITLE
Efficiency improvement to the distance functions (full vectorization)

### DIFF
--- a/bregclus/divergences.py
+++ b/bregclus/divergences.py
@@ -1,6 +1,60 @@
 import numpy as np
+import functools
 
-def euclidean(X, Y):
+def distance_function_vec(func):
+    """
+    This decorates any distance function that expects two vectors as input. 
+    """
+    @functools.wraps(func)
+    def wraped_distance(X, Y):
+        """
+        Computes a pairwise distance between two matrices.
+
+        Parameters
+        ----------
+            X: array-like, shape=(batch_size, n_features)
+            Input batch matrix.
+            Y: array-like, shape=(n_clusters, n_features)
+            Matrix in which each row represents the mean vector of each cluster.
+
+        Returns
+        -------
+            D: array-like, shape=(batch_size, n_clusters)
+            Matrix of paiwise dissimilarities between the batch and the cluster's parameters.
+
+        """
+        
+        # naive implementation (without vectorization idk if it possible to do it in a generic way... maybe with jax)
+        # probably it can be faster if we directly use numpy instead of list of compreensions to numpy
+        
+        # builds the np.array (batch_size, n_cluster) by testing the func for all combinations of XxY.
+        return np.array([[func(sample, cluster_center) for cluster_center in Y] for sample in X])
+
+    return wraped_distance
+
+def _euclidean_vectorized(X,Y):
+    """
+    Computes a pairwise Euclidean distance between two matrices: D_ij=||x_i-y_j||^2.
+
+    Parameters
+    ----------
+        X: array-like, shape=(batch_size, n_features)
+           Input batch matrix.
+        Y: array-like, shape=(n_clusters, n_features)
+           Matrix in which each row represents the mean vector of each cluster.
+
+    Returns
+    -------
+        D: array-like, shape=(batch_size, n_clusters)
+           Matrix of paiwise dissimilarities between the batch and the cluster's parameters.
+
+    """
+    
+    # same computation as the _old_euclidean function, but a new axis is added
+    # to X so that Y can be directly broadcast, speeding up computations
+    return np.sqrt(np.sum((np.expand_dims(X, axis=1)-Y)**2, axis=-1))
+
+def _old_euclidean(X, Y):
     """
     Computes a pairwise Euclidean distance between two matrices: D_ij=||x_i-y_j||^2.
 
@@ -20,7 +74,15 @@ def euclidean(X, Y):
     func = lambda x_i: np.sqrt(np.sum((x_i-Y)**2, axis=1))
     return np.array([func(x_i) for x_i in X])
 
-def mahalanobis(X, Y, cov):
+# expose the vectorized version as the default one
+euclidean=_euclidean_vectorized
+
+def _mahalanobis_vectorized(X, Y, cov):
+    
+    diff = np.expand_dims(np.expand_dims(X, axis=1)-Y, axis=-1)
+    return np.sum(np.squeeze(((np.linalg.pinv(cov)@diff)*diff)), axis=-1)
+
+def _old_mahalanobis(X, Y, cov):
     """
     Computes a pairwise Mahalanobis distance between two matrices: (x_i-y_j)^T Cov_j (x_i-y_j).
 
@@ -44,7 +106,13 @@ def mahalanobis(X, Y, cov):
         return np.squeeze(np.sum((np.linalg.pinv(cov)@diff)*diff, axis=1))
     return np.array([func(x_i) for x_i in X])
 
-def squared_manhattan(X, Y):
+mahalanobis = _mahalanobis_vectorized
+
+def _squared_manhattan_vectorized(X, Y):
+    
+    return np.sum(np.abs(np.expand_dims(X, axis=1)-Y), axis=-1)**2
+
+def _old_squared_manhattan(X, Y):
     """
     Computes a pairwise squared manhattan distance between two matrices: D_ij=sum(|x_i|-|y_j|)^2.
 
@@ -63,4 +131,6 @@ def squared_manhattan(X, Y):
     """
     func = lambda x_i: np.sum(np.abs(x_i-Y), axis=1)**2
     return np.array([func(x_i) for x_i in X])
+
+squared_manhattan = _squared_manhattan_vectorized
 

--- a/bregclus/divergences_test.py
+++ b/bregclus/divergences_test.py
@@ -1,0 +1,38 @@
+from bregclus.divergences import _old_squared_manhattan, _old_euclidean, _old_mahalanobis, _euclidean_vectorized, _mahalanobis_vectorized, _squared_manhattan_vectorized
+import numpy as np
+
+def test_euclidean_consistency():
+    # verifies if _old_euclidean and _euclidean_vectorized produce the same output
+    Y = np.random.uniform(size=(5, 1000))
+    
+    for i in range(1,4):
+        X = np.random.uniform(size=(100*10**i, 1000))
+        old_r = _old_euclidean(X, Y)
+        vec_r = _euclidean_vectorized(X,Y)
+        
+        assert (old_r==vec_r).all()
+        
+        
+def test_mahalanobis_consistency():
+    # verifies if _old_mahalanobis and _mahalanobis_vectorized produce the same output
+    Y = np.random.uniform(size=(5, 1000))
+    cov = np.random.uniform(size=(5, 1000, 1000))
+    
+    # the _old is to slow to run a with a lot of iterations
+    for i in range(1,2):
+        X = np.random.uniform(size=(1*10**i, 1000))
+        old_r = _old_mahalanobis(X, Y, cov)
+        vec_r = _mahalanobis_vectorized(X,Y, cov)
+        
+        assert (old_r==vec_r).all()
+        
+def test_squared_manhattan_consistency():
+    # verifies if _old_squared_manhattan and _squared_manhattan_vectorized produce the same output
+    Y = np.random.uniform(size=(5, 1000))
+    
+    for i in range(1,4):
+        X = np.random.uniform(size=(10*10**i, 1000))
+        old_r = _old_squared_manhattan(X, Y)
+        vec_r = _squared_manhattan_vectorized(X,Y)
+        
+        assert (old_r==vec_r).all()

--- a/bregclus/models.py
+++ b/bregclus/models.py
@@ -1,5 +1,5 @@
 import numpy as np
-from sklearn.base import BaseEstimator, ClusterMixin
+from sklearn.base import BaseEstimator, ClusterMixin, TransformerMixin
 from bregclus.divergences import euclidean
 
 class BregmanHard(BaseEstimator, ClusterMixin):


### PR DESCRIPTION
Hi @juselara1, first of all, thanks for this repository. I dont know if you are open to receive contributions to the code, but nevertheless I opened this pull request with the following improvements:

- Full vectorisation of the _euclidean_, _mahalanobis_ and _squared_manhattan_ distances. Before, each sample of each batch were iteratively processed, now the computation is directly performed over the entire batch thanks to broadcast. P.S. The speed up achieved on the mahalanobis is substancial, e.g., the _mahalanobis_hard.py_ runs in **0.5s** instead of **30s** on my machine. 
- Also added a generic non-optimized wrapped that makes any function distance between two vectos compatible with this code. For instance, this makes it possible to use distance function from spicy like:
```python
from bregclus.divergences import euclidean, mahalanobis, distance_function_vec
from scipy.spatial import distance

# makes the distance.jensenshannon compatible with this framework
d_jensenshannon = distance_function_vec(distance.jensenshannon)

model = BregmanHard(n_clusters=3, divergence=d_jensenshannon)
```
- Finally, by default I change the _euclidean_, _mahalanobis_ and _squared_manhattan_ function to use their vectorized version and leaved the previous code under the name __old_[distance name]_. Furthermore, I also added a divergences_test.py that ensures that the old and new functions are outputting the same values. (To run do: `pytest .`)
